### PR TITLE
Implement full CRUD for cats and update cat model

### DIFF
--- a/app/controllers/cats_controller.rb
+++ b/app/controllers/cats_controller.rb
@@ -1,16 +1,41 @@
 class CatsController < ApplicationController
   def index
+    @cats = Cat.all
+
+    render json: @cats
   end
 
   def show
+    @cat = Cat.find(params[:id])
+
+    render json: @cat
   end
 
   def create
+    @cat = Cat.create(
+      name: params[:name],
+      age: params[:age]
+    )
+
+    render json: @cat
   end
 
   def update
+    @cat = Cat.find(params[:id])
+
+    @cat.update(
+      name: params[:name],
+      age: params[:age]
+    )
+
+    render json: @cat
   end
 
   def destroy
+    @cat = Cat.find(params[:id])
+
+    @cat.destroy
+
+    render status: 204
   end
 end

--- a/app/models/cat.rb
+++ b/app/models/cat.rb
@@ -1,6 +1,2 @@
 class Cat < ApplicationRecord
-  def initialize(name, age)
-    @name = name
-    @age = age
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :cats, only: [:index]
+  resources :cats
 end

--- a/db/migrate/20200131162224_create_cats.rb
+++ b/db/migrate/20200131162224_create_cats.rb
@@ -1,7 +1,8 @@
 class CreateCats < ActiveRecord::Migration[6.0]
   def change
     create_table :cats do |t|
-
+      t.string :name
+      t.integer :age
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,8 @@
 ActiveRecord::Schema.define(version: 2020_01_31_162224) do
 
   create_table "cats", force: :cascade do |t|
+    t.string "name"
+    t.integer "age"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
Removed the previous cat model implementation because I did not need to
specify an initialize method in it.

Rolled back the previous DB migration because I forgot to write out the
name and age columns for the Cat DB table. They have now been properly
migrated.

Lastly, I wrote the full CRUD index, show, create, update, and destroy
actions for the Cats controller and enabled the routes for all actions.