### PR TITLE
Initializes owners controller and model

### DIFF
--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -1,0 +1,2 @@
+class OwnersController < ApplicationController
+end

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -1,0 +1,2 @@
+class Owner < ApplicationRecord
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :cats
+  resources :owners
 end

--- a/db/migrate/20200131172705_create_owners.rb
+++ b/db/migrate/20200131172705_create_owners.rb
@@ -1,0 +1,10 @@
+class CreateOwners < ActiveRecord::Migration[6.0]
+  def change
+    create_table :owners do |t|
+
+      t.string :name
+      t.integer :age
+      t.timestamps
+    end
+  end
+end

--- a/test/controllers/owners_controller_test.rb
+++ b/test/controllers/owners_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class OwnersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/owners.yml
+++ b/test/fixtures/owners.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/owner_test.rb
+++ b/test/models/owner_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class OwnerTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Generates a controller for Owners to which the cats will, in the future,
belong to.

Creates the Owner model and updates the migration file to store a name
and age for an owner instance.

Opens routes for all Owner actions despite them not yet being
implemented. In hindsight this was a bad idea as it makes sense to only
open the routes once the CRUD features have been created and tested.